### PR TITLE
Fixed a major error in README sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ def run():
 	m.login()
 	print("Logged in.")
 	m.send("tell {} Mbf test online".format(master))
-	m.process_triggers()
+	m.start_processing()
 
 if __name__ == '__main__':
 	run()


### PR DESCRIPTION
I was unable to run the sample code until making this change. When debugging I corrected the `m.process_triggers()` call to `process_triggers(m)` before quickly realizing that `m.print_output` does not exist until after `m.start_processing()` is called. (Where `m` is an `mbf` object.)

Leaving these changes with you as you have the most up-to-date version of this API.